### PR TITLE
action: enable gofmt lint; fix dupword.go formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3.2.0
       with:
         version: latest
+        args: --enable=gofmt
 
     - name: Build
       run: go build -v ./...

--- a/dupword.go
+++ b/dupword.go
@@ -75,7 +75,7 @@ type ignore struct {
 }
 
 func (a *ignore) String() string {
-	t := make([]string,0,  len(ignoreWord))
+	t := make([]string, 0, len(ignoreWord))
 	for k := range ignoreWord {
 		t = append(t, k)
 	}
@@ -83,7 +83,7 @@ func (a *ignore) String() string {
 }
 
 func (a *ignore) Set(w string) error {
-	for _, k := range strings.Split(w, ","){
+	for _, k := range strings.Split(w, ",") {
 		ignoreWord[k] = true
 	}
 	return nil


### PR DESCRIPTION
The PR fixes formatting in `dupword.go` by running `go fmt ./...`. Additionally, enables `gofmt` linter to prevent formatting issues in the future.