### PR TITLE
Ignore duplicate words in example test output

### DIFF
--- a/dupword.go
+++ b/dupword.go
@@ -128,7 +128,12 @@ func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func (a *analyzer) fixDuplicateWordInComment(pass *analysis.Pass, f *ast.File) {
+	isTestFile := strings.HasSuffix(pass.Fset.File(f.FileStart).Name(), "_test.go")
 	for _, cg := range f.Comments {
+		// avoid checking example outputs for duplicate words
+		if isTestFile && isExampleOutputStart(cg.List[0].Text) {
+			continue
+		}
 		var preLine *ast.Comment
 		for _, c := range cg.List {
 			update, keyword, find := a.Check(c.Text)
@@ -328,4 +333,11 @@ func ExcludeWords(word string) (exclude bool) {
 		return true
 	}
 	return false
+}
+
+func isExampleOutputStart(comment string) bool {
+	return strings.HasPrefix(comment, "// Output:") ||
+		strings.HasPrefix(comment, "// output:") ||
+		strings.HasPrefix(comment, "// Unordered output:") ||
+		strings.HasPrefix(comment, "// unordered output:")
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -34,4 +34,8 @@ func A() {
 	// so so this file done. // want `Duplicate words \(so\) found`
 	// 中文重复复单词无法检测，因为中文不使用空格来分割字符，我们都是用肉眼看的，哈哈哈哈。
 	// 除 非 写 成 这 样 样 子 ！  // want `Duplicate words \(样\) found`
+
+	// output:
+	// hello
+	// hello // want `Duplicate words \(hello\) found`
 }

--- a/testdata/src/a/a_test.go
+++ b/testdata/src/a/a_test.go
@@ -38,3 +38,37 @@ func TestA(t *testing.T) {
 		})
 	}
 }
+
+func ExampleA() {
+	// duplicate words in the example output below should be ignored
+
+	// Output:
+	// hello
+	// hello
+	// hello
+
+	// output:
+	// hello
+	// hello
+	// hello
+
+	// Unordered output:
+	// hello
+	// hello
+	// hello
+
+	// unordered output:
+	// hello
+	// hello
+	// hello
+
+	// this comment block _doesn't_ start with 'output:'
+	// output:
+	// hello
+	// hello // want `Duplicate words \(hello\) found`
+
+	// this also isn't an output block
+	// Unordered output:
+	// hello
+	// hello // want `Duplicate words \(hello\) found`
+}


### PR DESCRIPTION
It's common that output is repeated in these examples, e.g.[1], so add an exception for these in test files when detecting duplicates.

Even though the docs[2] only mention "// Output:" and "// Unordered output:" the lower case version of these also seems supported (see again[1]).

[1] https://go.googlesource.com/go/+/f38d42f2c4c6ad0d7cbdad5e1417cac3be2a5dcb/src/bytes/example_test.go#58
[2] https://pkg.go.dev/testing#hdr-Examples

Issue: https://github.com/Abirdcfly/dupword/issues/20