### PR TITLE
fix: remove toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/Abirdcfly/dupword
 
 go 1.22.0
 
-toolchain go1.23.2
-
 require golang.org/x/tools v0.26.0
 
 require (


### PR DESCRIPTION
As you are using an explicit Go version (`1.22.0`), you don't need `toolchain`.