### PR TITLE
check excludeWords without commas

### DIFF
--- a/dupword.go
+++ b/dupword.go
@@ -249,7 +249,7 @@ func CheckOneKey(raw, key string) (new string, findWord string, find bool) {
 			*/
 			symbol := raw[spaceStart:i]
 			if ((key != "" && curWord == key) || key == "") && curWord == preWord && curWord != "" {
-				if !ExcludeWords(curWord) {
+				if !ExcludeWords(cutTrailingCommas(curWord)) {
 					find = true
 					findWordMap[curWord] = true
 					newLine.WriteString(lastSpace)
@@ -270,7 +270,7 @@ func CheckOneKey(raw, key string) (new string, findWord string, find bool) {
 			// last position
 			word := raw[wordStart:]
 			if ((key != "" && word == key) || key == "") && word == preWord {
-				if !ExcludeWords(word) {
+				if !ExcludeWords(cutTrailingCommas(word)) {
 					find = true
 					findWordMap[word] = true
 				}
@@ -340,4 +340,12 @@ func isExampleOutputStart(comment string) bool {
 		strings.HasPrefix(comment, "// output:") ||
 		strings.HasPrefix(comment, "// Unordered output:") ||
 		strings.HasPrefix(comment, "// unordered output:")
+}
+
+// cutTrailingCommas is used to remove trailing commas of words.
+// The excludeWords are provided as comma-separated list, so it is
+// impossible to ignore "[word], [word]," matches otherwise
+func cutTrailingCommas(s string) string {
+	result, _ := strings.CutSuffix(s, ",")
+	return result
 }

--- a/dupword_test.go
+++ b/dupword_test.go
@@ -42,6 +42,10 @@ func Test(t *testing.T) {
 	analyzer2 := dupword.NewAnalyzer()
 	_ = analyzer.Flags.Set("ignore", "the,and")
 	analysistest.Run(t, analysistest.TestData(), analyzer2, "a_ignore_the_and")
+
+	analyzer3 := dupword.NewAnalyzer()
+	_ = analyzer3.Flags.Set("ignore", "anything")
+	analysistest.Run(t, analysistest.TestData(), analyzer3, "ignore_commas")
 }
 
 func Test_checkOneKey(t *testing.T) {

--- a/testdata/src/ignore_commas/a.go
+++ b/testdata/src/ignore_commas/a.go
@@ -1,0 +1,30 @@
+// MIT License
+//
+// Copyright (c) 2022 Abirdcfly
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package a
+
+import "fmt"
+
+func A() {
+	line := "this line contains some duplicate words with comma to ignore: anything, anything,"
+	fmt.Println(line)
+}


### PR DESCRIPTION
Hi,

I suggest this change to solve a problem we frequently have when using dupword with golangci-lint on code which contains SQL strings.
We frequently have multiple boolean columns next to each other, which leads to false positives on `TRUE, TRUE` or `FALSE, FALSE`. 
As `excludeWords` is splitted on `,` it is impossible to add exceptions for these cases without this change.

Let me know if I should change something with regards to the test - was unsure how "minimal" the test case should be.